### PR TITLE
Update redux-saga to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,6 +1100,53 @@
         }
       }
     },
+    "@redux-saga/core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-AsJYcpuYfM1cmxJvfhXs9HAFSZVEG17TMsLPlXH7+Hq5a5ZP4GqcbtijEmS2AC7NR5lLJHy8csxpqz22PeW5dw==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@redux-saga/deferred": "^1.0.1",
+        "@redux-saga/delay-p": "^1.0.1",
+        "@redux-saga/is": "^1.0.2",
+        "@redux-saga/symbols": "^1.0.1",
+        "@redux-saga/types": "^1.0.2",
+        "redux": ">=0.10 <5",
+        "typescript-tuple": "^2.1.0"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.0.1.tgz",
+      "integrity": "sha512-+gW5xQ93QXOOmRLAmX8x2Hx1HpbTG6CM6+HcdTSbJovh4uMWaGyeDECnqXSt8QqA/ja3s2nqYXLqXFKepIQ1hw=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.0.1.tgz",
+      "integrity": "sha512-0SnNDyDLUyB4NThtptAwiprNOnbCNhoed/Rp5JwS7SB+a/AdWynVgg/E6BmjsggLFNr07KW0bzn05tsPRBuU7Q==",
+      "requires": {
+        "@redux-saga/symbols": "^1.0.1"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.0.2.tgz",
+      "integrity": "sha512-WnaUOwYvPK2waWjzebT4uhL8zY76XNkzzpJ2EQJe8bN1tByvAjvT7MuJZTSshOhdHL5PsRO0MsH224XIXBJidQ==",
+      "requires": {
+        "@redux-saga/symbols": "^1.0.1",
+        "@redux-saga/types": "^1.0.2"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.0.1.tgz",
+      "integrity": "sha512-akKkzcVnb1RzJaZV2LQFbi51abvdICMuAKwwLoCjjxLbLAGIw9EJxk5ucNnWSSCEsoEQMeol5tkAcK+Xzuv1Bg=="
+    },
+    "@redux-saga/types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",
+      "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
+    },
     "@wisersolutions/eslint-config": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@wisersolutions/eslint-config/-/eslint-config-1.0.4.tgz",
@@ -5009,8 +5056,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -5314,7 +5360,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -6137,10 +6182,22 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
     "redux-saga": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.0.tgz",
-      "integrity": "sha1-CiMdsKFIkwHdmA9vL4jYztQY9yQ="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.0.2.tgz",
+      "integrity": "sha512-dHV256by3eF2AnBPx1l3HqazQFkErZ82HDXgh4jSRpT72OrX31wyg8DA1q8+0HvENRfJAyhT/4qT5yH/vVqFfw==",
+      "requires": {
+        "@redux-saga/core": "^1.0.2"
+      }
     },
     "regenerate": {
       "version": "1.4.0",
@@ -7191,6 +7248,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -7367,6 +7429,27 @@
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
+      }
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
       }
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "lodash.snakecase": "^4.1.1",
     "lodash.topairs": "^4.3.0",
     "lodash.topath": "^4.5.2",
-    "redux-saga": "^0.16.0"
+    "redux-saga": "^1.0.2"
   }
 }

--- a/src/ducks/asyncActionDuck.test.js
+++ b/src/ducks/asyncActionDuck.test.js
@@ -12,7 +12,10 @@ describe('asyncActionDuck', () => {
 
   it("performs effect on latest trigger, stores both the result and the effect's async status", async () => {
     const data = { some: 'data' }
-    const effect = jest.fn().mockResolvedValueOnce(data)
+    const effect = jest
+      .fn()
+      .mockResolvedValueOnce({ obsolete: 'data' })
+      .mockResolvedValueOnce(data)
     const { TYPE, saga, reducer, getResult, getStatus } = asyncActionDuck(TRIGGER_TYPE, effect)(factory)
 
     expect(TYPE).toBeDefined()
@@ -25,8 +28,9 @@ describe('asyncActionDuck', () => {
     const state = { dummy: 'state' }
     const dispatched = await runSagaWithActions(saga, () => state, ...triggers)
     const meta = { trigger: triggers[1] }
-    expect(effect).toHaveBeenCalledTimes(1)
+    // note that `effect` is called twice, because the first one goes off before the second trigger is consumed…
     expect(effect).toHaveBeenCalledWith(triggers[1].payload, state, triggers[1])
+    // …but only the latest result is reported when multiple triggers go off before the effect is finished
     expect(dispatched).toEqual([
       { type: TYPE.PENDING, meta: { trigger: triggers[0] } },
       { type: TYPE.PENDING, meta },

--- a/src/ducks/formValidationDuck.js
+++ b/src/ducks/formValidationDuck.js
@@ -1,5 +1,4 @@
-import { delay } from 'redux-saga'
-import { takeLatest } from 'redux-saga/effects'
+import { delay, takeLatest } from 'redux-saga/effects'
 
 import { combineReducers, composeReducers } from '../core'
 import { asyncActionStatusReducer, singleActionReducer } from '../reducers'

--- a/src/test/runSagaWithActions.js
+++ b/src/test/runSagaWithActions.js
@@ -1,24 +1,19 @@
-import EventEmitter from 'events'
 import { runSaga, stdChannel } from 'redux-saga'
 
 export async function runSagaWithActions(saga, getState = () => {}, ...actions) {
   const dispatched = []
 
-  const emitter = new EventEmitter()
   const channel = stdChannel()
-  emitter.on('action', channel.put)
-
-  const emitAction = (action) => emitter.emit('action', action)
 
   const testIO = {
     channel,
-    dispatch: action => emitAction(action) && dispatched.push(action),
+    dispatch: action => dispatched.push(action) && channel.put(action),
     getState
   }
 
   await runSaga(testIO, saga)
 
-  actions.forEach(emitAction)
+  actions.forEach(channel.put)
 
   return dispatched
 }

--- a/src/test/runSagaWithActions.js
+++ b/src/test/runSagaWithActions.js
@@ -1,22 +1,22 @@
-import { runSaga } from 'redux-saga'
+import EventEmitter from 'events'
+import { runSaga, stdChannel } from 'redux-saga'
 
 export async function runSagaWithActions(saga, getState = () => {}, ...actions) {
   const dispatched = []
-  let handleAction
-  await runSaga(
-    {
-      subscribe: callback => {
-        handleAction = callback
-        actions.forEach(handleAction)
-        return () => {}
-      },
-      dispatch: action => {
-        dispatched.push(action)
-        handleAction(action)
-      },
-      getState
-    },
-    saga
-  )
+
+  const emitter = new EventEmitter()
+  const channel = stdChannel()
+  emitter.on('action', channel.put)
+
+  const testIO = {
+    channel,
+    dispatch: action => emitter.emit('action', action) && dispatched.push(action),
+    getState
+  }
+
+  await runSaga(testIO, saga)
+
+  actions.forEach(action => testIO.dispatch(action))
+
   return dispatched
 }

--- a/src/test/runSagaWithActions.js
+++ b/src/test/runSagaWithActions.js
@@ -2,16 +2,19 @@ import { runSaga, stdChannel } from 'redux-saga'
 
 export async function runSagaWithActions(saga, getState = () => {}, ...actions) {
   const dispatched = []
-
   const channel = stdChannel()
 
-  const testIO = {
-    channel,
-    dispatch: action => dispatched.push(action) && channel.put(action),
-    getState
-  }
-
-  await runSaga(testIO, saga)
+  await runSaga(
+    {
+      channel,
+      dispatch(action) {
+        dispatched.push(action)
+        channel.put(action)
+      },
+      getState
+    },
+    saga
+  )
 
   actions.forEach(channel.put)
 

--- a/src/test/runSagaWithActions.js
+++ b/src/test/runSagaWithActions.js
@@ -8,15 +8,17 @@ export async function runSagaWithActions(saga, getState = () => {}, ...actions) 
   const channel = stdChannel()
   emitter.on('action', channel.put)
 
+  const emitAction = (action) => emitter.emit('action', action)
+
   const testIO = {
     channel,
-    dispatch: action => emitter.emit('action', action) && dispatched.push(action),
+    dispatch: action => emitAction(action) && dispatched.push(action),
     getState
   }
 
   await runSaga(testIO, saga)
 
-  actions.forEach(action => testIO.dispatch(action))
+  actions.forEach(emitAction)
 
   return dispatched
 }


### PR DESCRIPTION
Using a pre-release version of `redux-saga` in this library results in a conflict when using a 1.x version in a consuming React application; an error `effectRunner is not a function` is thrown, which some Googling suggests a version mismatch is the issue.

This fails 2 tests for me locally but since this is on a branch I am opting to push it / make a draft PR so we can see the failing tests in a common place (CircleCI).

- [x] `sagas` › `takeOne` › takes just the first action of a type
- [x] `asyncActionDuck` › performs effect on latest trigger, stores both the result and the effect's async status 

Planning on going through the [1.0 release notes](https://github.com/redux-saga/redux-saga/releases/tag/v1.0.0) (as a start) to resolve breaking changes.