### PR TITLE
Add error flag to asyncActionSaga

### DIFF
--- a/src/sagas/asyncActionSaga.js
+++ b/src/sagas/asyncActionSaga.js
@@ -13,6 +13,6 @@ export const asyncActionSaga = (
       const data = yield call(effect, ...getArgs(action, state))
       yield put({ type: SUCCESS, payload: data, meta })
     } catch (error) {
-      yield put({ type: FAILURE, payload: error, meta })
+      yield put({ type: FAILURE, payload: error, meta, error: true })
     }
   }

--- a/src/sagas/asyncActionSaga.test.js
+++ b/src/sagas/asyncActionSaga.test.js
@@ -31,7 +31,7 @@ describe('asyncActionSaga', () => {
       select(),
       put({ type: asyncType.PENDING, meta: { trigger } }),
       call(effect, trigger.payload, state, trigger),
-      put({ type: asyncType.FAILURE, payload: error, meta: { trigger } })
+      put({ type: asyncType.FAILURE, payload: error, meta: { trigger }, error: true })
     ])
   })
 })


### PR DESCRIPTION
Flux Standard Actions state:
 * An action MAY have an `error` property

> The optional `error` property MAY be set to `true` if the action represents an error

Unless we have a good reason not to, this seems like it would help with more universal error handling without having to check the type of the payload.