### PR TITLE
Add `ownProps` passthrough to `combineSelectors`

### DIFF
--- a/src/core/selectors.js
+++ b/src/core/selectors.js
@@ -14,4 +14,4 @@ export function createSelector(selector) {
   throw new Error(`"${selector}" is not a valid selector!`)
 }
 
-export const combineSelectors = selectorMap => state => mapValues(selectorMap, selector => selector(state))
+export const combineSelectors = selectorMap => (state, ownProps) => mapValues(selectorMap, selector => selector(state, ownProps))


### PR DESCRIPTION
When converting my redux implementation to the patterns we use throughout our applications, I found a discrepancy between the convenience that `combineSelectors` offers and the existing behavior of `mapStateToProps`, specifically: the passing through of the component's `ownProps` in addition to the redux `state`.

Base:
```js
connect(mapStateToProps, mapDispatchToProps)(Component)
```

---

#### Example _without_ `ownProps`

With redux (w/ too much knowledge about state shape):
```js
const mapStateToProps = state => ({
  simpleData: state.simpleData,
  otherData: state.otherData
})
```

With redux + selectors:
```js
const mapStateToProps = state => ({
  simpleData: simpleDataSelector(state),
  otherData: otherDataSelector(state)
})
```

Using `combineSelectors`:
```js
const mapStateToProps = combineSelectors({
  simpleData: simpleDataSelector,
  otherData: otherDataSelector
})
```

---

#### Example _with_ `ownProps`

With redux (w/ too much knowledge about state shape, but works today):
```js
const mapStateToProps = (state, ownProps) => ({
  simpleData: state.simpleData, // unchanged from above
  indexedData: state.indexedData[ownProps.id]
})
```

With redux + selectors (still works today):
```js
const mapStateToProps = (state, ownProps) => ({
  simpleData: simpleDataSelector(state), // unchanged from above
  indexedData: indexedDataSelector(state, ownProps.id)
})
```
(some discussion as to whether to pass `ownProps` through as-is or to just pass the relevant information. I've been leaning towards the latter to avoid selectors knowing about component props)

How I'd like to use `combineSelectors` (does not work 😞)
```js
const mapStateToProps = combineSelectors({
  simpleData: simpleDataSelector, // unchanged from above

  // With local handling of `ownProps`
  indexedData: (state, ownProps) => indexedDataSelector(state, ownProps.id)

  // With passing `ownProps` through
  indexedData: indexedDataSelector
})
```

---

As it stands now, when I find myself needing to use `ownProps` in a selector, I have to refactor the `connect` call for that component to move away from using `combineSelectors`, which is unfortunate and seems unnecessary.

The code change itself ends up being straightforward, given that `ownProps` is already passed to `mapStateToProps` and must only be passed through `combineSelectors`.

- [ ] **TODO:** Add test(s)